### PR TITLE
Add defense code when the logiwa doesn't provide storeID

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -27,6 +27,7 @@ import { EbayApiModule } from './modules/ebayApi.module';
 import { AmazonSPApiModule } from './modules/amazonSPApi.module';
 import { InterchangeableGroupsModule } from './modules/interchangeableGroups.module';
 import { AWSModule } from './modules/aws.module';
+import { SearsApiModule } from './modules/searsApi.module';
 
 @Module({
   imports: [
@@ -133,6 +134,10 @@ import { AWSModule } from './modules/aws.module';
             path: '/',
             module: ProductBundlesModule,
           },
+          {
+            path: '/',
+            module: SearsApiModule,
+          },
         ],
       },
     ]),
@@ -158,6 +163,7 @@ import { AWSModule } from './modules/aws.module';
     AmazonSPApiModule,
     InterchangeableGroupsModule,
     AWSModule,
+    SearsApiModule,
   ],
 })
 export class AppModule {}

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -17,7 +17,7 @@ export const util = {
 export const configuration = async (): Promise<Record<string, unknown>> => {
   const { config } = await import('./default');
   const environment = await import(`./${process.env.NODE_ENV || 'development'}`);
-  
+
   // object deep merge
   return util.merge(config, environment.config);
 };

--- a/src/config/default.ts
+++ b/src/config/default.ts
@@ -25,7 +25,7 @@ export const config = {
     orderFormFolderId: process.env.ORDER_FORM_FOLDER_ID,
   },
   sendGrid: {
-    apiKey: process.env.SEND_GRID_API_KEY
+    apiKey: process.env.SEND_GRID_API_KEY,
   },
   logiwaApiConfig: {
     username: process.env.LOGIWA_API_USERNAME,
@@ -36,7 +36,7 @@ export const config = {
     warehouseId: process.env.LOGIWA_API_WAREHOUSE_ID,
     numberOfApiCallPerSecond: process.env.LOGIWA_API_NUMBER_OF_API_CALL_PER_SECOND,
     jobRetryPeriod: process.env.LOGIWA_API_JOB_RETRY_PERIOD,
-    inventoryItemMapFilename: process.env.LOGIWA_API_INVENTORY_ITEM_MAP_FILENAME
+    inventoryItemMapFilename: process.env.LOGIWA_API_INVENTORY_ITEM_MAP_FILENAME,
   },
   walmartApiConfig: {
     username: process.env.WALMART_API_USERNAME,
@@ -49,7 +49,7 @@ export const config = {
     maCroixClientToken: {
       clientId: process.env.WALMART_API_MA_CLIENT_ID,
       clientSecret: process.env.WALMART_API_MA_CLIENT_SECRET,
-    }
+    },
   },
   ebayApiConfig: {
     baseUrl: process.env.EBAY_API_BASE_URL,
@@ -87,6 +87,12 @@ export const config = {
     consoleLoginLink: process.env.AWS_IAM_CONSOLE_LOGIN_LINK,
     awsRegion: process.env.AWS_REGION,
     stsUrl: process.env.AWS_STS_URL,
+  },
+  searsApiConfig: {
+    userId: process.env.SEARS_API_USERNAME,
+    sellerId: process.env.SEARS_API_SELLER_ID,
+    authorizationKey: process.env.SEARS_API_AUTHORIZATION_KEY,
+    baseUrl: process.env.SEARS_API_BASE_URL,
   },
   foo: 'dev-bar',
 };

--- a/src/config/development.ts
+++ b/src/config/development.ts
@@ -1,3 +1,3 @@
-import { ENV, ENVIRONMENT } from 'src/constants';
+import { ENVIRONMENT, ENV } from 'src/constants';
 
 export const config = { [ENVIRONMENT]: ENV.PRODUCTION };

--- a/src/controllers/searsApi.controller.ts
+++ b/src/controllers/searsApi.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { SearsApiService } from 'src/services/searsApi.service';
+
+@Controller('sears-api')
+export class SearsApiController {
+  constructor(private readonly searsApiService: SearsApiService) {}
+
+  @Get('shipping-carrier')
+  getShippingCarrier(): Promise<any> {
+    return this.searsApiService.getShippingCarrier();
+  }
+}

--- a/src/modules/searsApi.module.ts
+++ b/src/modules/searsApi.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SearsApiService } from 'src/services/searsApi.service';
+import { SearsApiController } from 'src/controllers/searsApi.controller';
+
+@Module({
+  providers: [SearsApiService],
+  controllers: [SearsApiController],
+  exports: [SearsApiService],
+})
+export class SearsApiModule {}

--- a/src/services/searsApi.service.ts
+++ b/src/services/searsApi.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios, { Method } from 'axios';
+import { HmacSHA256, enc } from 'crypto-js';
+import { getCurrentDate, toSearsDateFormat } from 'src/utils/dateTime.util';
+
+@Injectable()
+export class SearsApiService {
+  private readonly logger = new Logger(SearsApiService.name);
+  private searsApiconfig: SearsApiConfig;
+
+  constructor(private readonly configService: ConfigService) {
+    this.searsApiconfig = this.configService.get<SearsApiConfig>('searsApiConfig');
+  }
+
+  private buildQueryString(queryParams: { [key: string]: string }): string {
+    return Object.keys(queryParams)
+      .map((key: string): string => `${encodeURIComponent(key)}=${encodeURIComponent(queryParams[key])}`)
+      .join('&');
+  }
+
+  private getAuthorizationString(timeStamp: string): string {
+    const signature: string = this.getSignature(timeStamp);
+    return `HMAC-SHA256 emailaddress=${this.searsApiconfig.userId},timestamp=${timeStamp},signature=${signature}`;
+  }
+
+  private getSignature(timeStamp: string): string {
+    const stringToSign = `${this.searsApiconfig.sellerId}:${this.searsApiconfig.userId}:${timeStamp}`;
+    return HmacSHA256(stringToSign, this.searsApiconfig.authorizationKey).toString(enc.Hex);
+  }
+
+  private async searsApiCall({
+    endpoint,
+    method,
+    headers = {},
+    data,
+    queryParams = {},
+  }: SearsApiOptions): Promise<any> {
+    const timeStamp: string = toSearsDateFormat(getCurrentDate());
+    const queryString = this.buildQueryString(queryParams);
+    try {
+      const res = await axios({
+        method,
+        url: `${this.searsApiconfig.baseUrl}${endpoint}${queryString.length > 0 ? `?${queryString}` : ''}`,
+        headers: {
+          'Content-Type': 'application/xml; charset=utf-8',
+          authorization: this.getAuthorizationString(timeStamp),
+          ...headers,
+        },
+        data: data,
+        validateStatus: (status: number): boolean => status >= 200 && status < 501,
+      });
+
+      return res.data;
+    } catch (error) {
+      this.logger.error('searsApiCall error');
+      this.logger.error(error);
+
+      throw error;
+    }
+  }
+
+  async getShippingCarrier(): Promise<any> {
+    return this.searsApiCall({
+      endpoint: 'oms/shipping-carrier/v1',
+      method: 'GET',
+      queryParams: { sellerId: this.searsApiconfig.sellerId },
+    });
+  }
+}
+
+interface SearsApiConfig {
+  userId: string;
+  sellerId: string;
+  authorizationKey: string;
+  baseUrl: string;
+}
+
+interface SearsApiOptions {
+  endpoint: string;
+  method: Method;
+  headers?: { [key: string]: string };
+  data?: { [key: string]: any };
+  queryParams: { [key: string]: string };
+}

--- a/src/services/tasks.service.ts
+++ b/src/services/tasks.service.ts
@@ -84,7 +84,7 @@ export class TasksService {
               const [firstOrder] = orders;
 
               const orderDateStart = orders.reduce(
-                (orderDate: string, order: Orders) =>
+                (orderDate: string, order: Orders): string =>
                   orderDate.localeCompare(order.orderDate) < 0 ? orderDate : order.orderDate,
                 firstOrder.orderDate,
               );

--- a/src/utils/dateTime.util.ts
+++ b/src/utils/dateTime.util.ts
@@ -218,3 +218,14 @@ export const toAmazonDateFormat = (date: Date): string => {
 
   return `${yyyy}${mm}${dd}T${hh}${mi}${ss}Z`;
 };
+
+export const toSearsDateFormat = (date: Date): string => {
+  const yyyy = date.getUTCFullYear();
+  const mm = ('0' + (date.getUTCMonth() + 1)).slice(-2);
+  const dd = ('0' + date.getUTCDate()).slice(-2);
+  const hh = ('0' + date.getUTCHours()).slice(-2);
+  const mi = ('0' + date.getUTCMinutes()).slice(-2);
+  const ss = ('0' + date.getUTCSeconds()).slice(-2);
+
+  return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}Z`;
+};

--- a/src/utils/types.util.ts
+++ b/src/utils/types.util.ts
@@ -63,6 +63,10 @@ export const findMarketId = (channel: ChannelType, store: StoreType): number =>
   marketTable.find((market) => market.channel === channel && market.store === store).id ?? -1;
 export const findChannelTypeFromChannelId = (channelId: number): ChannelType =>
   marketTable.find((market) => market.channelId === channelId)?.channel;
+export const findChannelTypeFromStoreName = (storeName: string): ChannelType =>
+  marketTable.find(
+    (market) => market.channel && storeName.toLowerCase().indexOf(String(market.channel).toLowerCase()) > -1,
+  )?.channel;
 export const findStoreType = (storeName: string): StoreType =>
   storeName.toLowerCase().indexOf(StoreType.HAB.toLowerCase()) > -1 || storeName.toLowerCase().indexOf('skyhigh') > -1
     ? StoreType.HAB


### PR DESCRIPTION
- Add `findChannelTypeFromStoreName` function to get channel code
  - Sometimes, the Logiwa doesn't responses the `ChannelID` so, it causes `findChannelTypeFromChannelId` function error
  - Thus, we call `findChannelTypeFromChannelId` only the Logiwa provides `ChannelID`, otherwise, uses `findChannelTypeFromStoreName` using `StoreName` field